### PR TITLE
Fixed a slice allocate issue

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -26,7 +26,7 @@ func Image2ASCIIMatrix(image image.Image, imageConvertOptions *Options) []string
 	sz := newImage.Bounds()
 	newWidth := sz.Max.Y
 	newHeight := sz.Max.X
-	rawCharValues := make([]string, int(newWidth*newHeight))
+	rawCharValues := make([]string, 0, int(newWidth*newHeight+newWidth))
 	for i := 0; i < int(newWidth); i++ {
 		for j := 0; j < int(newHeight); j++ {
 			pixel := color.NRGBAModel.Convert(newImage.At(j, i))


### PR DESCRIPTION
1. The second arg of make is length, then the third is cap;
2. Reserving a position for the new line char("\n"), though slice can reassign its size automatically.