### PR TITLE
Update install instructions from to `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Image2ASCII is a library that converts images into ASCII images and provides com
 ## Installation
 
 ```bash
-go get github.com/qeesung/image2ascii
+go install github.com/qeesung/image2ascii@latest
 ```
 
 ## CLI usage


### PR DESCRIPTION
Looks like `go get` has been deprecated.

New method for installation is `go install <repo-url>@latest`

In this case:

```sh
go install github.com/qeesung/image2ascii@latest
```